### PR TITLE
Allow switching with L/R, fix with pause/play, remove stop song

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The latest 3DSX/CIA/3DS download can be found on the <a href="https://github.com
 ## Controls
 L+R or L+Up: Pause
 
-L+B: Stop
+ZL/ZR or L/R: Previous/Next Song
 
 L+Left: Show Controls
 

--- a/source/main.c
+++ b/source/main.c
@@ -288,6 +288,10 @@ err:
 	goto out;
 }
 
+void pausePlay() {
+
+}
+
 int main(int argc, char **argv)
 {
 	PrintConsole	topScreenLog, topScreenInfo, bottomScreen;
@@ -432,6 +436,22 @@ int main(int argc, char **argv)
 			// 	 */
 			// 	continue;
 			// }
+		}
+		// if R is pressed first
+		if ((kHeld & KEY_R) && (kDown & KEY_L))
+		{
+			if(isPlaying() == false)
+				continue;
+
+			consoleSelect(&topScreenLog);
+			if(togglePlayback() == true)
+				puts("Paused");
+			else
+				puts("Playing");
+
+			keyLComboPressed = true;
+			keyRComboPressed = true;
+			continue;
 		}
 
 		if((kDown & KEY_UP ||
@@ -588,7 +608,7 @@ int main(int argc, char **argv)
 			}
 			keyLComboPressed = false;
 		}
-		bool goToPrevFile = (kDown & KEY_ZR) || keyLActivation;
+		bool goToPrevFile = (kDown & KEY_ZL) || keyLActivation;
 		// don't go to ../
 		if (goToPrevFile && fileNum > 1) {
 			fileNum -= 1;

--- a/source/main.c
+++ b/source/main.c
@@ -288,10 +288,6 @@ err:
 	goto out;
 }
 
-void pausePlay() {
-
-}
-
 int main(int argc, char **argv)
 {
 	PrintConsole	topScreenLog, topScreenInfo, bottomScreen;
@@ -417,25 +413,6 @@ int main(int argc, char **argv)
 				keyLComboPressed = true;
 				continue;
 			}
-
-			// /* Stop */
-			// if(kDown & KEY_B)
-			// {
-			// 	stopPlayback();
-
-			// 	/* Clear playback information. */
-			// 	consoleSelect(&topScreenInfo);
-			// 	consoleClear();
-			// 	consoleSelect(&topScreenLog);
-			// 	//consoleClear();
-
-			// 	changeFile(NULL, &playbackInfo);
-
-			// 	/* If the playback thread is currently playing, it will now
-			// 	 * stop and tell the Watchdog thread to display "Stopped".
-			// 	 */
-			// 	continue;
-			// }
 		}
 		// if R is pressed first
 		if ((kHeld & KEY_R) && (kDown & KEY_L))

--- a/source/main.c
+++ b/source/main.c
@@ -30,7 +30,7 @@ static void showControls(void)
 {
 	printf("Button mappings:\n"
 			"Pause: L+R or L+Up\n"
-			"Stop: L+B\n"
+			"Previous/Next Song: ZL/ZR or L/R\n"
 			"A: Open File\n"
 			"B: Go up folder\n"
 			"Start: Exit\n"
@@ -402,24 +402,24 @@ int main(int argc, char **argv)
 				continue;
 			}
 
-			/* Stop */
-			if(kDown & KEY_B)
-			{
-				stopPlayback();
+			// /* Stop */
+			// if(kDown & KEY_B)
+			// {
+			// 	stopPlayback();
 
-				/* Clear playback information. */
-				consoleSelect(&topScreenInfo);
-				consoleClear();
-				consoleSelect(&topScreenLog);
-				//consoleClear();
+			// 	/* Clear playback information. */
+			// 	consoleSelect(&topScreenInfo);
+			// 	consoleClear();
+			// 	consoleSelect(&topScreenLog);
+			// 	//consoleClear();
 
-				changeFile(NULL, &playbackInfo);
+			// 	changeFile(NULL, &playbackInfo);
 
-				/* If the playback thread is currently playing, it will now
-				 * stop and tell the Watchdog thread to display "Stopped".
-				 */
-				continue;
-			}
+			// 	/* If the playback thread is currently playing, it will now
+			// 	 * stop and tell the Watchdog thread to display "Stopped".
+			// 	 */
+			// 	continue;
+			// }
 		}
 
 		if((kDown & KEY_UP ||


### PR DESCRIPTION
Resolves #66 and resolves #78 
Tested on hardware (old 3DS XL), seems to work fine.

Changes:
- Allow switching of files with L/R also (upon key release) #66
- Remove L+B (stop) and update README/show controls https://github.com/deltabeard/ctrmus/issues/66#issuecomment-3201682553
- Allow pause/play when pressing R first in the L+R key combination #78
